### PR TITLE
Fix for #29

### DIFF
--- a/middleware/models/voyageai.js
+++ b/middleware/models/voyageai.js
@@ -36,7 +36,15 @@ class VoyageAIModel {
         documents.forEach((doc,index) => {
             docMap[index] = doc;
         });
-        const docStrings = documents.map((doc) => doc.description);
+        const docStrings = documents.map((doc) => {
+            if(doc.description){
+                return doc.description;
+            }else if(doc.title){
+                return doc.title;
+            }else{
+                return "";
+            }
+        });
         try{
             const resp = await this.client.post(
                 "rerank",


### PR DESCRIPTION
Voyage AI reranker code now defaults to using title field from doc if description does not exist. Lack of description field was causing errors.