### PR TITLE
Fix scoring display in HybridScore component to handle undefined values gracefully

### DIFF
--- a/components/hybrid-score.js
+++ b/components/hybrid-score.js
@@ -3,7 +3,7 @@ import { palette } from '@leafygreen-ui/palette';
 function HybridScore({result}) {
     return (
         <div style={{paddingTop:"5px"}}>
-            <em style={{fontSize:"smaller"}}>Scoring for this result: {`${result.fts_score.toFixed(3)} + ${result.vs_score.toFixed(3)} = ${result.score.toFixed(3)}`}</em>
+            <em style={{fontSize:"smaller"}}>Scoring for this result: {`${(result.fts_score || 0).toFixed(3)} + ${(result.vs_score || 0).toFixed(3)} = ${(result.score || 0).toFixed(3)}`}</em>
             <div key={`${result._id}scores`} style={{display:"grid",gridTemplateColumns:"45px 4lvh 50% 4lvh 45px",gap:"5px",alignItems:"start"}}>
                 <div style={{color:palette.blue.light1, fontSize:"smaller"}}>Lexical</div>
                 <span style={{color:palette.blue.light1, fontSize:"smaller"}}>{`${Math.round((result.fts_score/result.score)*100)}%`}</span>


### PR DESCRIPTION
When combined results come only from one pipeline, their score is "null" and it breaks the experience on the UI after a NPE.